### PR TITLE
Fix ESM error in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,10 @@ import react from '@vitejs/plugin-react'
 import dts from 'vite-plugin-dts'
 import checker from 'vite-plugin-checker'
 import eslint from 'vite-plugin-eslint'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const path = require('path')
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {


### PR DESCRIPTION
## Summary
- use ESM imports in `vite.config.ts`
- compute `__dirname` using `import.meta.url`

## Testing
- `yarn install`
- `yarn dev`

------
https://chatgpt.com/codex/tasks/task_e_6845d48fee54832d95eb35510623b341